### PR TITLE
Update MapTilePurchaseSystemPatches.cs

### DIFF
--- a/Code/Patches/MapTilePurchaseSystemPatches.cs
+++ b/Code/Patches/MapTilePurchaseSystemPatches.cs
@@ -122,11 +122,11 @@ namespace FiveTwentyNineTiles
         /// <summary>
         /// Checks to see if this tile is one of the first nine; if so, the cost is free.
         /// </summary>
-        /// <param name="cost">Calculated tile cost.</param>
-        /// <param name="numTiles">Number of selected tiles processed this update.</param>
         /// <param name="ownedTiles">Number of already owned tiles.</param>
+        /// <param name="numTiles">Number of selected tiles processed this update.</param>
+        /// <param name="cost">Calculated tile cost.</param>
         /// <returns>0 if this tile is one of the first nine, otherwise returns the calculated cost.</returns>
-        private static float CheckFreeTiles(float cost, int numTiles, int ownedTiles)
+        private static float CheckFreeTiles(int ownedTiles, int numTiles, float cost)
         {
             // Check tile count.
             if (numTiles + ownedTiles < 9)

--- a/Code/Patches/MapTilePurchaseSystemPatches.cs
+++ b/Code/Patches/MapTilePurchaseSystemPatches.cs
@@ -77,8 +77,8 @@ namespace FiveTwentyNineTiles
                     {
                         // Insert call to our custom method.
                         Mod.Instance.Log.Debug("found second m_Cost store");
-                        yield return new CodeInstruction(OpCodes.Ldloc_S, 22);
                         yield return new CodeInstruction(OpCodes.Ldloc_S, 7);
+                        yield return new CodeInstruction(OpCodes.Ldloc_S, 8);
                         yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(MapTilePurchaseSystemPatches), nameof(CheckFreeTiles)));
                     }
                 }


### PR DESCRIPTION
Fix the order of parameters to the cost calculation function (CheckFreeTiles) to match the order they are placed on the stack in the code transpiler (UpdateStatusTranspiler).